### PR TITLE
Update rainforest device name and handler to match their path. 

### DIFF
--- a/devicetypes/augoisms/rainforest-handler.src/rainforest-handler.groovy
+++ b/devicetypes/augoisms/rainforest-handler.src/rainforest-handler.groovy
@@ -19,7 +19,7 @@
 
 metadata {
 
-	definition(name: "RainforestEagle", namespace: "augoisms", author: "Justin Walker") {
+	definition(name: "Rainforest Handler", namespace: "augoisms", author: "Justin Walker") {
 		capability "Power Meter"
 		capability "Refresh"
 		capability "Sensor"

--- a/smartapps/augoisms/rainforest-manager.src/rainforest-manager.groovy
+++ b/smartapps/augoisms/rainforest-manager.src/rainforest-manager.groovy
@@ -18,7 +18,7 @@
  */
  
 definition(
-	name: "Rainforest Eagle Manager",
+	name: "Rainforest Manager",
 	namespace: "augoisms",
 	author: "Justin Walker",
 	description: "Monitor your whole-house energy use by connecting to your Rainforest Eagle",


### PR DESCRIPTION
Found out through https://community.smartthings.com/t/github-integration-issues-why-devices-are-skipped-solved/98011/2 that the name in the file, should also math the name in the path:

> /namespace/device-name.src/device-name.groovy
> 
> But the metadata definition name ALSO has to match that name.

I tried to pull from my branch, and it worked fine.